### PR TITLE
Removed DTPS from the software architecture diagram

### DIFF
--- a/src/_images/software-architecture/software-architecture.drawio.png
+++ b/src/_images/software-architecture/software-architecture.drawio.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf24a6473c2b11a25c067d89ebbc88e20553decac30c37e7ea4e15165a698149
-size 169718
+oid sha256:fde961c687f480aac3b6172c75e884fa69fe2807a6447ebfb834e6fbcd05227f
+size 137820


### PR DESCRIPTION
As we move towards using exclusively ROS on the drone we abandon (for now) the DTPS container stack.