### PR TITLE
DTSW-7485: switch flight controller flashing from ArduPilot to PX4

### DIFF
--- a/src/_static/duckiedrone-px4.params
+++ b/src/_static/duckiedrone-px4.params
@@ -1,0 +1,43 @@
+# Onboard parameters for Duckiedrone DD24 (PX4 mamba-f405-mk2)
+#
+# These parameters override the PX4 v1.16 defaults to configure the drone for:
+#   - Rangefinder-only altitude estimation (no GPS/MAG/BARO fusion)
+#   - Quadrotor airframe and control allocation
+#   - DD24-appropriate logging, IMU, and safety behavior
+#
+# Calibration data (CAL_*) is intentionally omitted - calibrate sensors on the
+# target flight controller via QGroundControl after loading these parameters.
+#
+# Source: derived from a working Gazebo simulation (PX4 v1.16, airframe 4016 -
+# x500_lidar_down). See Jira DTSW-7245 / DTSW-7484.
+#
+# Vehicle-Id Component-Id Name Value Type
+1	1	EKF2_BARO_CTRL	0	6
+1	1	EKF2_GPS_CHECK	2047	6
+1	1	EKF2_GPS_CTRL	0	6
+1	1	EKF2_HGT_REF	2	6
+1	1	EKF2_MAG_TYPE	0	6
+1	1	EKF2_MIN_RNG	0.009999999776482582	9
+1	1	EKF2_REQ_GPS_H	0.500000000000000000	9
+1	1	EKF2_RNG_CTRL	1	6
+1	1	EKF2_RNG_FOG	1.000000000000000000	9
+1	1	MAV_PROTO_VER	2	6
+1	1	MAV_TYPE	2	6
+1	1	CA_AIRFRAME	0	6
+1	1	CA_METHOD	2	6
+1	1	CA_ROTOR_COUNT	4	6
+1	1	CA_ROTOR2_KM	-0.050000000745058060	9
+1	1	CA_ROTOR3_KM	-0.050000000745058060	9
+1	1	IMU_DGYRO_CUTOFF	20.000000000000000000	9
+1	1	IMU_GYRO_FFT_EN	1	6
+1	1	IMU_GYRO_RATEMAX	800	6
+1	1	IMU_INTEG_RATE	250	6
+1	1	MC_AT_EN	1	6
+1	1	NAV_DLL_ACT	2	6
+1	1	COM_LOW_BAT_ACT	3	6
+1	1	COM_MODE_ARM_CHK	1	6
+1	1	SDLOG_DIRS_MAX	7	6
+1	1	SDLOG_MODE	1	6
+1	1	SDLOG_PROFILE	131	6
+# BAT1_N_CELLS: 4S default for DD24; verify it matches the actual battery installed.
+1	1	BAT1_N_CELLS	4	6

--- a/src/drone-handling/flight-controller-initialization.md
+++ b/src/drone-handling/flight-controller-initialization.md
@@ -1,100 +1,160 @@
 ```{seo}
-:description: Instructions to initialize the flight controller on the Duckietown Duckiedrone model DD24. 
-:keywords: Duckiedrone, Duckietown, autonomous drone, uav, flight controller, initialization
+:description: Instructions to initialize the flight controller on the Duckietown Duckiedrone model DD24 by flashing the PX4 bootloader and firmware.
+:keywords: Duckiedrone, Duckietown, autonomous drone, uav, flight controller, initialization, PX4, dfu-util, mamba-f405-mk2
 ```
 
 (dd24-fc-init)=
 # Initializing the Flight Controller
 
 ```{needget}
-* A base station computer
+* A base station computer (Linux recommended; macOS works with `brew install dfu-util`)
 * Flight Controller
 * USB to USB-C cable
 ---
-* An up-to-date, initialized Flight Controller
+* An up-to-date, initialized Flight Controller running PX4
 ```
 
-The Flight Controller (FC) implements several low-level behaviors, e.g., stabilizing the Duckiedrone around roll, pitch, and yaw through three different PID controllers. Correctly configuring the Flight Controller is critical for flying safely.  
+The Flight Controller (FC) implements several low-level behaviors, e.g., stabilizing the Duckiedrone around roll, pitch, and yaw through three different PID controllers. Correctly configuring the Flight Controller is critical for flying safely.
 
-## Installing Dependencies and Flashing Ardupilot Firmware
+The DD24 runs the [PX4 Autopilot](https://px4.io/) firmware, built for the `mamba-f405-mk2` target. Flashing is performed entirely from the command line with [`dfu-util`](https://dfu-util.sourceforge.net/) so that the procedure is fully scriptable and does not require a graphical flasher.
 
-### 1. Install dfu-util and screen:
+```{note}
+The flashing is a two-stage process:
 
-- Connect the flight controller to a laptop running Ubuntu.
-- Update the package list:
+1. **Flash the PX4 bootloader** (the [`omnibusf4sd_bl`](https://github.com/PX4/PX4-Bootloader) bootloader, which is the canonical bootloader for STM32F405-based boards using PX4 board ID `42`, including the Diatone Mamba F405 MK2).
+2. **Flash the PX4 firmware** built for the `mamba-f405-mk2` target on top of the bootloader.
+
+Both stages are performed via `dfu-util` while the FC is in STM32 DFU mode.
+```
+
+## 1. Install `dfu-util`
+
+Connect the flight controller to a laptop running Ubuntu and update the package list:
 
 ```bash
 sudo apt update
-```
-
-- Install `dfu-util` and `screen`:
-
-```bash
 sudo apt install dfu-util
 ```
 
-### 2. Entering DFU Mode:
+```{tip}
+Use `dfu-util` version `>= 0.9`. Older versions may silently truncate writes on STM32F4 targets.
+```
 
-- Disconnect the USB cable connecting the Flight Controller to the Raspberry Pi and reconnect it while keeping the BOOT button on the side of the flight controller pressed.\
+(Optional but recommended) install a udev rule so `dfu-util` does not need `sudo`:
+
+```bash
+sudo tee /etc/udev/rules.d/45-stm32-dfu.rules > /dev/null <<'EOF'
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="df11", MODE="0664", GROUP="plugdev"
+SUBSYSTEM=="usb", ATTR{idVendor}=="26ac", MODE="0664", GROUP="plugdev"
+EOF
+sudo udevadm control --reload && sudo udevadm trigger
+```
+
+## 2. Enter DFU Mode
+
+- Disconnect the USB cable connecting the Flight Controller to the Raspberry Pi.
+- Reconnect it to your base station while keeping the **BOOT** button on the side of the flight controller pressed.
 
 ```{figure} ../_images/fc-setup/speedybee-boot-button.png
 
-SpeedyBee F405v3 BOOT button location.
+Flight controller BOOT button location.
+
 ```
 
-- After a couple of seconds you can release the BOOT button.
-- Execute the command `sudo dfu-util -l`, you should see a list of devices available to be flashed, as in the following image:
+```{todo}
+Replace `speedybee-boot-button.png` with a photo of the BOOT button location on the current DD24 flight controller.
+```
+
+- After a couple of seconds, release the BOOT button.
+- Verify that the board is enumerated as an STM32 DFU device:
+
+```bash
+dfu-util -l
+```
+
+You should see one or more interfaces with the vendor/product ID `0483:df11` ("STMicroelectronics STM Device in DFU Mode"), as in the following image:
 
 ```{figure} ../_images/fc-setup/dfu-util-devices-list.png
 
-List of devices in DFU mode output by `dfu-util`.
+Output of `dfu-util -l` with the FC in DFU mode.
 ```
 
-### 3. Download and Flash the Firmware:
+## 3. Flash the PX4 Bootloader
 
-Run the following command:
+Download the prebuilt `omnibusf4sd_bl` bootloader hex shipped with the PX4 user guide and convert it to a raw binary that `dfu-util` can flash:
 
 ```bash
-wget https://github.com/duckietown/duckiedrone-ardupilot-driver/blob/6f3bfa7fe7ad8ab06c829e1f915409ab7486f42f/assets/speedybeef4v3_bl.bin
+sudo apt install binutils-arm-none-eabi   # provides arm-none-eabi-objcopy
+curl -L -o omnibusf4sd_bl.hex \
+  https://github.com/PX4/PX4-user_guide/raw/main/assets/flight_controller/omnibus_f4_sd/omnibusf4sd_bl_d52b70cb39.hex
+arm-none-eabi-objcopy -I ihex -O binary omnibusf4sd_bl.hex omnibusf4sd_bl.bin
 ```
 
-Run `dfu-util` to flash the firmware:
+```{tip}
+The bootloader hash suffix `d52b70cb39` is tracked in the PX4 user guide; if the URL above 404s, re-resolve it from
+[the PX4 bootloader-from-Betaflight page](https://docs.px4.io/main/en/advanced_config/bootloader_update_from_betaflight.html).
+You can also build the bootloader from source with `make omnibusf4sd_bl` from a clone of [`PX4/PX4-Bootloader`](https://github.com/PX4/PX4-Bootloader).
+```
+
+With the FC still in DFU mode, flash the bootloader to address `0x08000000`:
 
 ```bash
-sudo dfu-util -a 0 -s 0x08000000:leave -d 0483:df11 -D speedybeef4v3_bl.bin
+dfu-util -a 0 --dfuse-address 0x08000000:leave -d 0483:df11 -D omnibusf4sd_bl.bin
 ```
 
 ```{tip}
 Explanation of the `dfu-util` command:
 
-* `sudo`: Grants administrative privileges to run the command.
-* `dfu-util`: The name of the utility used for flashing firmware.
-* `-a 0`: Selects the first DFU device (adjust if there are multiple).
-* `-s 0x08000000:leave`: Sets the address and size for the new firmware.
-* `-d 0483:df11`: Defines the vendor ID (0483) and product ID (df11) for Ardupilot devices.
-* `-D speedybeef4v3_bl.bin`: Specifies the filename of the firmware to be flashed.
+* `-a 0`: selects the first DFU alternate setting (the internal flash).
+* `--dfuse-address 0x08000000:leave`: writes to the start of flash and reboots the board into the freshly written image after the write completes.
+* `-d 0483:df11`: matches the STM32 ROM DFU device.
+* `-D omnibusf4sd_bl.bin`: the file to flash.
 ```
 
-The flashing process might take a few minutes. Once finished, the flight controller will reboot.
+After the flash completes (this takes a few seconds), the board will reboot. It will now enumerate as a **PX4 bootloader** device — you can verify with `lsusb` (the device will show up under the `26AC` USB vendor ID, e.g., `26AC:0011`) or by listing serial devices:
 
-### Install the Ardupilot firmware
-
-You will need to flash a custom build of the Ardupilot firmware, it can be downloaded from [this link](https://github.com/duckietown/duckiedrone-ardupilot-driver/blob/6f3bfa7fe7ad8ab06c829e1f915409ab7486f42f/assets/arducopter.bin).
-
-1. Start QGroundControl.
-2. Go into the "Vehicle Setup" tab by first clicking on the QGroundControl logo.
-      ![vehicle_setup](../_images/fc-setup/vehicle_setup.png)
-3. Go into the "Firmware Flasher" tab by clicking on "Firmware" in the left sidebar.
-      ![firmware_tab](../_images/fc-setup/firmware_tab.png)
-4. Connect the Flight Controller through USB and select the `Ardupilot` option for the firmware, ticking `Advanced Settings` and then selecting `Custom firmware file...`. A file manager window will open to allow you to pick the `arducopter.bin` file you have just downloaded.
-      ![firmware_selection](../_images/fc-setup/firmware_selection.png)
-
-Here is a video summing up the process:
-
-```{vimeo} 1045397898
+```bash
+ls /dev/serial/by-id/    # should list a *PX4_BL* entry
 ```
 
-## Starting the drone software stack
+## 4. Flash the PX4 Firmware
+
+Download the PX4 firmware binary for the `mamba-f405-mk2` target:
+
+```bash
+curl -L -O https://github.com/duckietown/duckiedrone-px4-driver/releases/latest/download/diatone_mamba-f405-mk2_default.bin
+```
+
+```{todo}
+The URL above is a placeholder. Until the firmware is published as a release asset of `duckietown/duckiedrone-px4-driver`, the binary is available as `diatone_mamba-f405-mk2_default.bin` on Jira issue [DTSW-7484](https://ethidsc.atlassian.net/browse/DTSW-7484). Update the URL once the release is cut.
+```
+
+Put the FC back into DFU mode (disconnect, hold BOOT, reconnect), confirm it shows up again in `dfu-util -l`, then flash the firmware to the application offset `0x08008000`:
+
+```bash
+dfu-util -a 0 --dfuse-address 0x08008000:leave -d 0483:df11 -D diatone_mamba-f405-mk2_default.bin
+```
+
+```{important}
+The PX4 firmware is loaded **at offset `0x08008000`**, not at `0x08000000`. The first 32 KiB of flash is reserved for the bootloader you wrote in step 3. Writing the firmware to `0x08000000` would overwrite the bootloader.
+```
+
+After the flash completes the board reboots and runs PX4. The boot sequence is: STM32 reset → PX4 bootloader at `0x08000000` → PX4 firmware at `0x08008000`.
+
+````{tip}
+**Alternative — use the PX4 serial uploader.**
+
+Once the bootloader is flashed (step 3), you can also flash the firmware over USB-CDC with the PX4 uploader script. This is the canonical PX4 path — it verifies that the firmware's board ID matches the bootloader's reported board ID before erasing flash:
+
+```bash
+git clone --depth 1 https://github.com/PX4/PX4-Autopilot.git
+python3 PX4-Autopilot/Tools/px4_uploader.py diatone_mamba-f405-mk2_default.px4
+```
+
+Use this approach if you have the `.px4` file (a JSON-wrapped, board-ID-tagged firmware envelope) instead of the raw `.bin`. The `dfu-util` flow above is preferred for fully programmatic deployments.
+````
+
+## 5. Starting the drone software stack
 
 Now you will need to start the drone software stack, allowing you to connect to the flight controller from your laptop.
 
@@ -119,7 +179,7 @@ To start the flight software stack execute the command
 
 Wait for the command to terminate before proceeding to the next step.
 
-## Connecting to the Flight Controller
+## 6. Connecting to the Flight Controller
 
 ```{attention}
 Unplug the battery from your drone!
@@ -128,10 +188,13 @@ Unplug the battery from your drone!
 (qgroundcontrol-connection)=
 ### Installing QGroundControl and Restoring the correct parameters
 
-By following these steps, you will be able to install QGroundControl, connect to your flight controller via TCP, and restore your vehicle’s parameters from a `.param` file. You can download the correct `.param` file from [this link](https://raw.githubusercontent.com/duckietown/duckiedrone-ardupilot-driver/refs/heads/main/assets/speedybeef405_ardupilot.params).
+By following these steps you will be able to install QGroundControl, connect to your flight controller via TCP, and restore your vehicle's parameters from a `.params` file. The `.params` file contains the PX4 parameters that differ from the upstream defaults (rangefinder-only altitude estimation, quadrotor airframe configuration, controller tuning, etc.). You can download it from [this link](https://github.com/duckietown/duckiedrone-px4-driver/releases/latest/download/duckiedrone-px4.params).
 
+```{todo}
+The URL above is a placeholder, mirroring the firmware release path. Until the `.params` is published, use the curated file shipped with this book at [`_static/duckiedrone-px4.params`](../_static/duckiedrone-px4.params).
+```
 
-1. Install QGroundControl:`
+1. Install QGroundControl:
    - Go to the [QGroundControl website](http://qgroundcontrol.com/) and download the installer for your operating system (Windows, macOS, or Linux).
    - Follow the installation instructions for your OS:
      - **Windows**: Run the installer and follow the prompts.
@@ -141,22 +204,22 @@ By following these steps, you will be able to install QGroundControl, connect to
 
 1. Connect to Your Vehicle via TCP:
    - Open QGroundControl on your computer.
-   - Go to the **Comm Links** section by clicking on the **Q** application icon in the top left corner.
+   - Go to the **Application Settings → Comm Links** section by clicking on the **Q** application icon in the top left corner.
    - Select **Add** to create a new communication link.
-   - Choose **TCP Link** from the dropdown.
-   - Set the **Host Address** to `<robot_name>.local` and the **Port** to `5760`.
+   - Choose **TCP** from the dropdown.
+   - Set the **Host Address** to `<robot_name>.local` and the **Port** to the port exposed by the `mavlink-proxy` service on your Duckiedrone (default: `5760`).
    - Click **Connect** to establish the connection with your flight controller.
 
 1. Access the Vehicle Setup:
-   - Once connected, open the menu by clicking on the by clicking on the **Q** application icon in the top left corner and open the **Vehicle Setup** page from the popup menu that appears.
+   - Once connected, open the menu by clicking on the **Q** application icon in the top left corner and open the **Vehicle Setup** page from the popup menu that appears.
 
 1. Navigate to Parameters:
    - In the Vehicle Setup menu, select the **Parameters** tab to view the configurable parameters for your vehicle.
 
-1. Load the `.param` File:
+1. Load the `.params` File:
    - In the Parameters screen, click on the **Tools** menu in the top right corner.
    - Select **Load from file…** from the dropdown menu.
-   - Browse to the location of your `.param` file on your computer, select it, and click **Open**.
+   - Browse to the location of your `.params` file on your computer, select it, and click **Open**.
 
 1. Apply the Parameters:
    - QGroundControl will load and apply the parameters from the file to your vehicle. Progress indicators or messages will confirm that the parameters are being applied.
@@ -165,22 +228,40 @@ By following these steps, you will be able to install QGroundControl, connect to
    - After loading the parameters, it is usually necessary to reboot the flight controller for changes to take effect.
    - You can reboot the vehicle by selecting **Reboot Vehicle** from the **Tools** menu.
 
-Here is a video summing up how to restore the parameters after having connected to the Flight Controller:
-
-```{vimeo} 1010195551
+```{todo}
+Re-record the parameter-loading walkthrough video for PX4 (the previous Vimeo capture targeted ArduPilot/QGC).
 ```
 
 ### Additional Tips
 
 - **Multiple Loads:** Some parameters may require multiple loads until they are all applied correctly.
 - **Check for Errors:** Ensure QGroundControl does not report any errors during the parameter loading process.
+- **On-board calibration is mandatory:** the shipped `.params` file deliberately omits all `CAL_*` (accelerometer/gyro/magnetometer/barometer calibration) entries because those are tied to a specific board's sensor IDs. Run the **Sensors** calibration in QGroundControl on the actual flight controller after loading the parameters.
 
 ## Troubleshooting
 
 ```{trouble}
+`dfu-util` shows no devices.
+---
+The FC has not entered DFU mode. Disconnect USB, hold the BOOT button while reconnecting, then run `dfu-util -l` again. On Linux, also confirm there is no kernel driver claiming the device (e.g., `ModemManager`) by checking `dmesg` after plug-in.
+```
+
+```{trouble}
+After flashing, the board does not enumerate as a PX4 bootloader.
+---
+The most common cause is that the firmware was flashed to `0x08000000` instead of `0x08008000`, overwriting the bootloader. Re-enter DFU mode and re-run step 3 to restore the bootloader, then re-run step 4 with the correct address.
+```
+
+```{trouble}
+`px4_uploader.py` reports "expected board ID 42, got X".
+---
+The wrong bootloader was flashed in step 3. Re-flash `omnibusf4sd_bl.bin` (board ID `42` matches the `mamba-f405-mk2` PX4 target).
+```
+
+```{trouble}
 I am having issues following the instructions!
 ---
-We’re happy to support and to hear your feedback! Please post a question on our StackOverflow, you can find the instructions on how to join it [here](https://duckietown.slack.com/archives/CHHQJ0E0H/p1670874390660429).
+We're happy to support and to hear your feedback! Please post a question on our StackOverflow, you can find the instructions on how to join it [here](https://duckietown.slack.com/archives/CHHQJ0E0H/p1670874390660429).
 
 You can also contact us via Slack at the following channel: [duckietown-sky-help](https://duckietown.slack.com/archives/CJWNCG667)
 ```

--- a/src/flying/environment-setup.md
+++ b/src/flying/environment-setup.md
@@ -46,7 +46,7 @@ Replace `ROBOT_NAME` with the hostname you assigned to your Duckiedrone. On the 
 Wait for the command to terminate before continuing. When it finishes the drone is running:
 
 *   `dashboard` — the web UI you will use to fly
-*   `ros2-mavros` — the MAVROS bridge between ROS 2 and the PX4/ArduPilot flight controller
+*   `ros2-mavros` — the MAVROS bridge between ROS 2 and the PX4 flight controller
 *   `mavlink-proxy`, `driver-tof`, `state-estimator`, `pid-controller`, `visual-odometry` — the flight stack
 
 ## 3. Open the Duckietown Dashboard

--- a/src/flying/flying-your-drone.md
+++ b/src/flying/flying-your-drone.md
@@ -72,7 +72,7 @@ The widget reflects live state — it polls `/mavros/state` and refreshes its AR
 
 ### Flight modes
 
-The drone runs PX4 (or an equivalent ArduPilot build) through MAVROS. The dashboard exposes three of PX4's flight modes:
+The drone runs PX4 through MAVROS. The dashboard exposes three of PX4's flight modes:
 
 | Mode | PX4 name | When to use |
 |---|---|---|


### PR DESCRIPTION
## Summary

- Rewrite [src/drone-handling/flight-controller-initialization.md](src/drone-handling/flight-controller-initialization.md) for PX4 on the `mamba-f405-mk2` target. Both stages use `dfu-util` for a fully programmatic flow: `omnibusf4sd_bl` bootloader at `0x08000000`, then `diatone_mamba-f405-mk2_default.bin` firmware at `0x08008000`. A `px4_uploader.py` + `.px4` alternative is documented as a tip.
- Add [src/_static/duckiedrone-px4.params](src/_static/duckiedrone-px4.params) — 28 curated rows covering the rangefinder-only EKF2 altitude config (DTSW-7245), quadrotor airframe/control allocation, IMU, logging, and safety. `CAL_*` and `SIM_GZ_*` are intentionally excluded so it's safe to load on hardware.
- Drop residual "or an equivalent ArduPilot build" / "PX4/ArduPilot" mentions in [src/flying/flying-your-drone.md](src/flying/flying-your-drone.md) and [src/flying/environment-setup.md](src/flying/environment-setup.md).

Source binaries are attached to [DTSW-7484](https://ethidsc.atlassian.net/browse/DTSW-7484).

## Open follow-ups (marked inline as `{todo}`)

- Refresh the BOOT-button photo for the current DD24 flight controller.
- Publish the firmware and `.params` as release assets of `duckietown/duckiedrone-px4-driver`; replace the placeholder URLs.
- Re-record the QGC parameter-loading walkthrough video (the previous Vimeo capture was for ArduPilot).

## Test plan

- [ ] Build the book locally (`jupyter-book build src/`) and confirm the flashing page renders without warnings.
- [ ] Walk through the new procedure end-to-end on a real Mamba F405 MK2 / SpeedyBee F405 with the binaries from DTSW-7484.
- [ ] In QGC, load `duckiedrone-px4.params` onto a freshly-flashed FC and confirm no errors during apply.
- [ ] Run the QGC sensor calibration after parameter load (the file deliberately omits `CAL_*`).

[DTSW-7484]: https://ethidsc.atlassian.net/browse/DTSW-7484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ