### PR TITLE
DTSW-7823: switch DD24 FC firmware to dd24-mamba-f405-mk2-v1.15.4-1

### DIFF
--- a/src/_static/duckiedrone-px4.params
+++ b/src/_static/duckiedrone-px4.params
@@ -1,7 +1,13 @@
-# Onboard parameters for Duckiedrone DD24 (PX4 mamba-f405-mk2)
+# Onboard parameters for Duckiedrone DD24 (PX4 mamba-f405-mk2 v2)
 #
 # These parameters override the PX4 v1.16 defaults to configure the drone for:
-#   - Rangefinder-only altitude estimation (no GPS/MAG/BARO fusion)
+#   - Rangefinder-only altitude estimation (no GPS / MAG / BARO fusion)
+#   - External-vision plumbing in place but disabled by default
+#     (set EKF2_EV_CTRL=7 for pos+vel or 15 to also fuse vision yaw, once a
+#      VIO publishes VISION_POSITION_ESTIMATE / ODOMETRY)
+#   - Magnetometer fusion explicitly disabled (the Mamba F405 MK2 v2 has no
+#     mag fitted, and the firmware shipped from
+#     dd24-mamba-f405-mk2-v1.16.1-2 onwards no longer compiles in mag drivers)
 #   - Quadrotor airframe and control allocation
 #   - DD24-appropriate logging, IMU, and safety behavior
 #
@@ -9,15 +15,17 @@
 # target flight controller via QGroundControl after loading these parameters.
 #
 # Source: derived from a working Gazebo simulation (PX4 v1.16, airframe 4016 -
-# x500_lidar_down). See Jira DTSW-7245 / DTSW-7484.
+# x500_lidar_down). See Jira DTSW-7245 / DTSW-7484 / DTSW-7823.
 #
 # Vehicle-Id Component-Id Name Value Type
 1	1	EKF2_BARO_CTRL	0	6
+1	1	EKF2_EV_CTRL	0	6
 1	1	EKF2_GPS_CHECK	2047	6
 1	1	EKF2_GPS_CTRL	0	6
 1	1	EKF2_HGT_REF	2	6
-1	1	EKF2_MAG_TYPE	0	6
+1	1	EKF2_MAG_TYPE	5	6
 1	1	EKF2_MIN_RNG	0.009999999776482582	9
+1	1	EKF2_OF_CTRL	0	6
 1	1	EKF2_REQ_GPS_H	0.500000000000000000	9
 1	1	EKF2_RNG_CTRL	1	6
 1	1	EKF2_RNG_FOG	1.000000000000000000	9

--- a/src/_static/duckiedrone-px4.params
+++ b/src/_static/duckiedrone-px4.params
@@ -1,23 +1,36 @@
 # Onboard parameters for Duckiedrone DD24 (PX4 mamba-f405-mk2 v2)
 #
-# These parameters override the PX4 v1.16 defaults to configure the drone for:
-#   - Rangefinder-only altitude estimation (no GPS / MAG / BARO fusion)
+# These parameters override the PX4 v1.15.4 defaults to configure the drone for:
+#   - No GPS / MAG / BARO at the system level (SYS_HAS_* = 0) so preflight
+#     does not require sensors that the v2 board does not have
+#   - Rangefinder-only altitude estimation (EKF2_HGT_REF = 2, EKF2_RNG_CTRL = 1)
 #   - External-vision plumbing in place but disabled by default
-#     (set EKF2_EV_CTRL=7 for pos+vel or 15 to also fuse vision yaw, once a
+#     (set EKF2_EV_CTRL = 7 for pos+vel or 15 to also fuse vision yaw, once a
 #      VIO publishes VISION_POSITION_ESTIMATE / ODOMETRY)
-#   - Magnetometer fusion explicitly disabled (the Mamba F405 MK2 v2 has no
-#     mag fitted, and the firmware shipped from
-#     dd24-mamba-f405-mk2-v1.16.1-2 onwards no longer compiles in mag drivers)
-#   - Quadrotor airframe and control allocation
+#   - Magnetometer fusion explicitly disabled (EKF2_MAG_TYPE = 5)
+#   - Quadrotor airframe and control allocation (MAV_TYPE = 2,
+#     CA_AIRFRAME = 0, CA_ROTOR_COUNT = 4)
+#   - CBRK_SUPPLY_CHK set so preflight does not flag the missing
+#     system_power rail on the v2 board
 #   - DD24-appropriate logging, IMU, and safety behavior
 #
 # Calibration data (CAL_*) is intentionally omitted - calibrate sensors on the
 # target flight controller via QGroundControl after loading these parameters.
 #
+# Recommended firmware: duckietown/PX4-Autopilot release
+#   dd24-mamba-f405-mk2-v1.15.4-1 (PX4 v1.15.4 + ICM42688P PR #25047).
+# A v1.16.1-2 build also exists but has an unbisected param-related boot
+# regression and is not the recommended target at the moment.
+#
 # Source: derived from a working Gazebo simulation (PX4 v1.16, airframe 4016 -
-# x500_lidar_down). See Jira DTSW-7245 / DTSW-7484 / DTSW-7823.
+# x500_lidar_down) and verified on real hardware. See Jira DTSW-7245 /
+# DTSW-7484 / DTSW-7822 / DTSW-7823.
 #
 # Vehicle-Id Component-Id Name Value Type
+1	1	SYS_HAS_BARO	0	6
+1	1	SYS_HAS_MAG	0	6
+1	1	SYS_HAS_GPS	0	6
+1	1	CBRK_SUPPLY_CHK	894281	6
 1	1	EKF2_BARO_CTRL	0	6
 1	1	EKF2_EV_CTRL	0	6
 1	1	EKF2_GPS_CHECK	2047	6
@@ -28,7 +41,6 @@
 1	1	EKF2_OF_CTRL	0	6
 1	1	EKF2_REQ_GPS_H	0.500000000000000000	9
 1	1	EKF2_RNG_CTRL	1	6
-1	1	EKF2_RNG_FOG	1.000000000000000000	9
 1	1	MAV_PROTO_VER	2	6
 1	1	MAV_TYPE	2	6
 1	1	CA_AIRFRAME	0	6

--- a/src/drone-handling/flight-controller-initialization.md
+++ b/src/drone-handling/flight-controller-initialization.md
@@ -122,7 +122,11 @@ ls /dev/serial/by-id/    # should list a *PX4_BL* entry
 Download the PX4 firmware binary for the `mamba-f405-mk2` target:
 
 ```bash
-curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.16.1-1/diatone_mamba-f405-mk2_default.bin
+curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.16.1-2/diatone_mamba-f405-mk2_default.bin
+```
+
+```{note}
+Starting with `dd24-mamba-f405-mk2-v1.16.1-2` the firmware is built specifically for the **v2 hardware variant** of the Mamba F405 MK2, which ships **without** an on-board barometer or magnetometer. Their drivers are no longer compiled in, and `SYS_HAS_BARO` / `SYS_HAS_MAG` are set to `0` by default so preflight does not flag the missing sensors.
 ```
 
 Put the FC back into DFU mode (disconnect, hold BOOT, reconnect), confirm it shows up again in `dfu-util -l`, then flash the firmware to the application offset `0x08008000`:
@@ -143,7 +147,7 @@ After the flash completes the board reboots and runs PX4. The boot sequence is: 
 Once the bootloader is flashed (step 3), you can also flash the firmware over USB-CDC with the PX4 uploader script. This is the canonical PX4 path — it verifies that the firmware's board ID matches the bootloader's reported board ID before erasing flash:
 
 ```bash
-curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.16.1-1/diatone_mamba-f405-mk2_default.px4
+curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.16.1-2/diatone_mamba-f405-mk2_default.px4
 git clone --depth 1 https://github.com/PX4/PX4-Autopilot.git
 python3 PX4-Autopilot/Tools/px4_uploader.py diatone_mamba-f405-mk2_default.px4
 ```
@@ -186,6 +190,10 @@ Unplug the battery from your drone!
 ### Installing QGroundControl and Restoring the correct parameters
 
 By following these steps you will be able to install QGroundControl, connect to your flight controller via TCP, and restore your vehicle's parameters from a `.params` file. The `.params` file contains the PX4 parameters that differ from the upstream defaults (rangefinder-only altitude estimation, quadrotor airframe configuration, controller tuning, etc.) and is shipped alongside this book at [`_static/duckiedrone-px4.params`](../_static/duckiedrone-px4.params).
+
+```{note}
+The shipped param file sets `EKF2_EV_CTRL = 0` so the EKF does not try to fuse vision before a VIO is online. Once a VIO publishes `VISION_POSITION_ESTIMATE` / `ODOMETRY` over MAVLink, raise `EKF2_EV_CTRL` to `7` (fuse vision pos + vel) or `15` (also fuse vision yaw — recommended on this magless airframe).
+```
 
 1. Install QGroundControl:
    - Go to the [QGroundControl website](http://qgroundcontrol.com/) and download the installer for your operating system (Windows, macOS, or Linux).

--- a/src/drone-handling/flight-controller-initialization.md
+++ b/src/drone-handling/flight-controller-initialization.md
@@ -122,11 +122,13 @@ ls /dev/serial/by-id/    # should list a *PX4_BL* entry
 Download the PX4 firmware binary for the `mamba-f405-mk2` target:
 
 ```bash
-curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.16.1-2/diatone_mamba-f405-mk2_default.bin
+curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.15.4-1/diatone_mamba-f405-mk2_default.bin
 ```
 
 ```{note}
-Starting with `dd24-mamba-f405-mk2-v1.16.1-2` the firmware is built specifically for the **v2 hardware variant** of the Mamba F405 MK2, which ships **without** an on-board barometer or magnetometer. Their drivers are no longer compiled in, and `SYS_HAS_BARO` / `SYS_HAS_MAG` are set to `0` by default so preflight does not flag the missing sensors.
+Use **`dd24-mamba-f405-mk2-v1.15.4-1`** for the DD24 — this is the build on which the shipped `duckiedrone-px4.params` file is known to load and save cleanly. The v2 hardware variant of the Mamba F405 MK2 ships **without** an on-board barometer or magnetometer; the param file restores `SYS_HAS_BARO=0`, `SYS_HAS_MAG=0`, `SYS_HAS_GPS=0`, and `CBRK_SUPPLY_CHK=894281` so preflight does not flag the missing sensors.
+
+A newer `dd24-mamba-f405-mk2-v1.16.1-2` build also exists (with baro/mag drivers stripped at compile time) but currently has an unbisected param-related boot regression. Avoid it for now.
 ```
 
 Put the FC back into DFU mode (disconnect, hold BOOT, reconnect), confirm it shows up again in `dfu-util -l`, then flash the firmware to the application offset `0x08008000`:
@@ -147,7 +149,7 @@ After the flash completes the board reboots and runs PX4. The boot sequence is: 
 Once the bootloader is flashed (step 3), you can also flash the firmware over USB-CDC with the PX4 uploader script. This is the canonical PX4 path — it verifies that the firmware's board ID matches the bootloader's reported board ID before erasing flash:
 
 ```bash
-curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.16.1-2/diatone_mamba-f405-mk2_default.px4
+curl -L -O https://github.com/duckietown/PX4-Autopilot/releases/download/dd24-mamba-f405-mk2-v1.15.4-1/diatone_mamba-f405-mk2_default.px4
 git clone --depth 1 https://github.com/PX4/PX4-Autopilot.git
 python3 PX4-Autopilot/Tools/px4_uploader.py diatone_mamba-f405-mk2_default.px4
 ```


### PR DESCRIPTION
## Summary

Switch the recommended DD24 flight-controller firmware to the new [`dd24-mamba-f405-mk2-v1.15.4-1`](https://github.com/duckietown/PX4-Autopilot/releases/tag/dd24-mamba-f405-mk2-v1.15.4-1) release and update `src/_static/duckiedrone-px4.params` to be self-contained on any build.

### Why 1.15.4 and not 1.16

I cut two firmware releases today (in order):

1. [`dd24-mamba-f405-mk2-v1.16.1-2`](https://github.com/duckietown/PX4-Autopilot/releases/tag/dd24-mamba-f405-mk2-v1.16.1-2) — based on `release/1.16` + cherry-pick of PX4#25047 + baro/mag drivers stripped at compile time. Boots cleanly with defaults.
2. [`dd24-mamba-f405-mk2-v1.15.4-1`](https://github.com/duckietown/PX4-Autopilot/releases/tag/dd24-mamba-f405-mk2-v1.15.4-1) — based on duckietown `1.15.4-duckietown` + a GCC 13 `-Waddress` compat cherry-pick. Boots cleanly with defaults.

Loading the full `duckiedrone-px4.params` set on (1) and then `param save` + reboot brought the v1.16.1-2 build into a state where USB-CDC stops enumerating on the next boot. We recovered twice by mass-erasing the parameter MTD region and re-flashing. On (2) the same load + save + reboot dance survived all four sub-steps of the bisect — including `MAV_PROTO_VER=2` and `NAV_DLL_ACT=2`, the params I had flagged as the highest risk. So the value set is fine on 1.15.4; the 1.16 regression is in the firmware build, not in the params.

Until that 1.16 regression is bisected, **the DD24 should be flashed with 1.15.4-1**.

### Changes in this PR

**`src/_static/duckiedrone-px4.params`** — 30 → 31 entries:
- Add `SYS_HAS_BARO=0`, `SYS_HAS_MAG=0`, `SYS_HAS_GPS=0`, `CBRK_SUPPLY_CHK=894281` (previously baked into 1.16's `rc.board_defaults`; the 1.15.4 branch never had those, so they need to be in the .param file)
- Remove `EKF2_RNG_FOG` (added upstream after v1.15.4; not in 1.15.4's param namespace, was an `ERR` line during load)
- Update header comments to reflect 1.15.4 + cross-reference the 1.16 release

**`src/drone-handling/flight-controller-initialization.md`**:
- Firmware download URL `dd24-mamba-f405-mk2-v1.16.1-2` → `dd24-mamba-f405-mk2-v1.15.4-1` (both `.bin` and `.px4`)
- Reword the firmware note to explain why 1.15.4 is preferred and that 1.16.1-2 is currently parked on the side

## Companion tickets

- **DTSW-7822** — PX4 firmware change(s)
- **DTSW-7823** — this opmanual change

## Test plan

- [x] `dd24-mamba-f405-mk2-v1.15.4-1` published with correctly named `.bin` and `.px4` assets
- [x] Full `duckiedrone-px4.params` load via MAVLink PARAM_SET → `param save` → reboot survives on `lc39a`-built `1.15.4-mamba-imu`
- [ ] Render the book locally and verify the new admonition renders correctly
- [ ] Walk a fresh user through the doc from § 1 to § 6 and confirm a freshly assembled DD24 can be brought up to "armable in Altitude mode" on the new firmware

## Notes

- The five params that fail to load (`SDLOG_*`, `IMU_GYRO_FFT_EN`, `MC_AT_EN`) are not compiled into either constrained-flash build. Leaving them in the `.param` file is harmless (loader logs an `ERR` line each); we keep them so that if someone ever uses a less-constrained image the same file Just Works.
- The previous PR commit (e5247e7) targeted 1.16; this PR's second commit (a3153c4) refocuses it on 1.15.4 — kept as a separate commit so the history makes the pivot visible. Squash-merging is fine.