### PR TITLE
docs(dd24): point supported LXs to DD24 repos (DTSW-7769)

### DIFF
--- a/src/learning-experiences/supported-lxs.md
+++ b/src/learning-experiences/supported-lxs.md
@@ -1,6 +1,6 @@
 ```{seo}
-:description: Explore supported Duckiedrone (DD24) learning experiences, including Linux, networking, ROS, sensor integration, PID tuning, and localization.
-:keywords: Duckiedrone learning, DD24 Linux, ROS introduction, IMU sensors, Time of Flight sensor, camera integration, PID tuning, Kalman filtering, localization
+:description: Explore supported Duckiedrone (DD24) learning experiences, including Linux, networking, ROS, sensor integration (IMU, Time of Flight, camera), and altitude PID tuning.
+:keywords: Duckiedrone learning, DD24 Linux, ROS introduction, IMU sensors, Time of Flight sensor, camera integration, altitude PID tuning
 ```
 
 (dd24-supported-lxs)=
@@ -15,17 +15,17 @@
 * Skills
 ```
 
-Learning experiences for the Duckiedrone are hosted on GitHub. Instructions for engaging in them are available at the following links:
+Learning experiences for the Duckiedrone are hosted on GitHub. Instructions for engaging in them are available in each repository's `README`, at the following links:
 
+<!-- Not yet ported to the new DD24 format:
 - [Linux and Networking](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/linux-and-networking)
 - [Introduction to ROS](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/introduction-to-ros-lx)
-- [Duckiedrone's Sensors - IMU](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/dd21-sensors-imu)
-- [Duckiedrone's Sensors - Time Of Flight Sensor](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/dd21-sensors-tof)
-- [Duckiedrone's Sensors - Camera](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/dd21-sensors-camera)
-- [Duckiedrone height PID tuning](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/dd21-pid-tuning-lx)
-- [Duckiedrone Kalman Filtering](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/dd21-ukf-lx)
-- [Duckiedrone Localization](https://github.com/duckietown/duckietown-lx/tree/duckiedrone-lxs/dd21-localization-lx)
+-->
+- [Duckiedrone's Sensors - IMU](https://github.com/duckietown/dd24-sensors-imu-lx-solution)
+- [Duckiedrone's Sensors - Time of Flight Sensor](https://github.com/duckietown/dd24-sensors-tof-lx-solution)
+- [Duckiedrone's Sensors - Camera](https://github.com/duckietown/dd24-sensors-camera-lx-solution)
+- [Duckiedrone Altitude PID Tuning](https://github.com/duckietown/dd24-pid-tuning-lx-solution)
 
 ```{todo}
-update from DD21 to DD24 LXs
+Replace the `*-lx-solution` repository links above with the learner-facing exercise repositories (`dd24-<name>`) once they are published.
 ```


### PR DESCRIPTION
## Summary

Updates the DD24 [Supported Learning Experiences](https://docs.duckietown.com/ente/opmanual-dd24/learning-experiences/supported-lxs.html) page to point to the new DD24 LXs (per the [Sky MOOC handoff notes](https://ethidsc.atlassian.net/wiki/spaces/DTSKY/pages/3640360962)), replacing the old DD21 links.

- Replaces the DD21 sensor/PID links with the four new DD24 LXs: **IMU**, **ToF**, **Camera**, **Altitude PID tuning**.
- Drops the DD21-only **Kalman Filtering** and **Localization** entries (no DD24 equivalent yet).
- Links point to the `*-lx-solution` repos (the only complete, consistently-present set today; learner-facing `dd24-<name>` repos aren't published yet).
- Comments out **Linux and Networking** and **Introduction to ROS** — not yet ported to the new DD24 format.
- Removes the stale `update from DD21 to DD24 LXs` TODO and adds one to swap solution repos for learner repos once published.

## Notes / follow-ups

- ⚠️ The **Camera** LX repo (`dd24-sensors-camera-lx-solution`) is currently **private** — the link will 404 publicly until it's made public.
- These are **solution** repos (full answer code), not learner exercise repos — tracked by the new TODO.