### PR TITLE
DTSW-8069-update-FC-parameters-to-enable-MavROS2-and-FC-talk-to-each-other

### DIFF
--- a/src/40-duckiedrone-handling/flying-your-drone.md
+++ b/src/40-duckiedrone-handling/flying-your-drone.md
@@ -1,6 +1,6 @@
 ```{seo}
-:description: Fly your Duckiedrone (DD24) from the Duckietown Dashboard using the arming widget, the virtual joystick, and the LOITER / ALTITUDE / OFFBOARD flight-mode selector.
-:keywords: Duckiedrone, DD24, fly duckiedrone, Duckietown Dashboard, mavros arming, PX4 flight modes, OFFBOARD, ALTCTL, LOITER
+:description: Fly your Duckiedrone (DD24) from the Duckietown Dashboard using the arming widget, the virtual joystick, and the STABILIZED / LOITER / ALTITUDE / OFFBOARD flight-mode selector.
+:keywords: Duckiedrone, DD24, fly duckiedrone, Duckietown Dashboard, mavros arming, PX4 flight modes, STABILIZED, manual flight, OFFBOARD, ALTCTL, LOITER
 ```
 
 (flying_your_drone)=
@@ -65,17 +65,18 @@ The Duckiedrone default mission, before arming.
 The **Arm / Disarm** widget is the primary flight control. It has three elements:
 
 *   An **ARM / DISARM** toggle at the top-left of the widget.
-*   A three-button **FLIGHT MODE** selector: `LOITER`, `ALTITUDE`, `OFFBOARD`.
+*   A four-button **FLIGHT MODE** selector: `STABILIZED`, `LOITER`, `ALTITUDE`, `OFFBOARD`.
 *   A red **KILL** switch that cuts motor power immediately when clicked.
 
 The widget reflects the live state — it polls `/mavros/state` and refreshes its ARM and FLIGHT MODE indicators whenever the flight controller state changes. If the toggle flips on its own, that reflects a real transition on the flight controller (for example, an auto-disarm).
 
 ### Flight modes
 
-The drone runs PX4 through MAVROS. The dashboard exposes three of PX4's flight modes:
+The drone runs PX4 through MAVROS. The dashboard exposes four of PX4's flight modes:
 
 | Mode | PX4 name | When to use |
 |---|---|---|
+| `STABILIZED` | `STABILIZED` | PX4 keeps the drone level when the sticks are centered, but **you control the throttle directly**, with no altitude or position hold. Use this for your first manual flights: it needs only the IMU attitude estimate, so it arms reliably on a GPS-less drone. |
 | `LOITER` | `AUTO.LOITER` | Ground-safe default. The drone is idle and armable but will not accept manual stick input. |
 | `ALTITUDE` | `ALTCTL` | PX4 holds altitude automatically; you command roll, pitch, and yaw from the virtual joystick (or from a physical RC). Use this when you want PX4's internal attitude control loops to do the stabilization. |
 | `OFFBOARD` | `OFFBOARD` | PX4 tracks setpoints published by an external node on `/mavros/setpoint_*`. Use this when you are writing your own controller and want PX4 to only handle low-level attitude control. |
@@ -83,12 +84,21 @@ The drone runs PX4 through MAVROS. The dashboard exposes three of PX4's flight m
 ```{important}
 PX4 only **accepts** an `OFFBOARD` request when it is already receiving setpoints on `/mavros/setpoint_raw/local` (or an equivalent topic) at **>2 Hz**. If no setpoints are being published, PX4 will silently ignore the mode switch and the drone will stay in its previous mode. Start your setpoint publisher **before** clicking `OFFBOARD`.
 
-`ALTITUDE` similarly requires valid manual-control input (stick values on `/mavros/manual_control/send`) or it will fall back to `LOITER`.
+`STABILIZED` and `ALTITUDE` similarly require valid manual-control input (stick values on `/mavros/manual_control/send`) or they will fall back to `LOITER`.
+```
+
+```{warning}
+In `STABILIZED` the throttle is **fully manual**. PX4 does not hold height for you, so if you lower or release the throttle the drone descends. Keep a hand on the throttle at all times and be ready to hit **KILL**.
 ```
 
 ### The Remote Control (virtual joystick) widget
 
-Next to the arming widget, the **Remote Control** widget publishes stick values to `/mavros/manual_control/send`. In `ALTITUDE` mode, moving the joystick tilts the drone; in `OFFBOARD` mode, the joystick is ignored (your setpoint publisher takes over).
+Next to the arming widget, the **Remote Control** widget publishes stick values to `/mavros/manual_control/send` using two on-screen gimbals, laid out like a Mode 2 RC transmitter:
+
+*   **Left gimbal**: throttle (up/down) and yaw (left/right). Throttle rests at the bottom (`0`) and *holds* wherever you leave it; yaw springs back to center.
+*   **Right gimbal**: roll (left/right) and pitch (forward/back); both spring back to center.
+
+In `STABILIZED` and `ALTITUDE` modes the gimbals fly the drone; in `OFFBOARD` mode they are ignored (your setpoint publisher takes over).
 
 ## First flight
 
@@ -110,13 +120,24 @@ Be prepared to hit the **KILL** switch at any moment. The kill switch will disar
 
     ::::{tab-set}
 
-    :::{tab-item} Fly with PX4's attitude stabilization (recommended first flight)
+    :::{tab-item} Fly in STABILIZED (recommended first flight)
+
+    1.  In the **Remote Control** widget, make sure the **left gimbal** (throttle) is at the **bottom** (`THR: 0`) and the **right gimbal** is centered.
+    1.  In the arming widget, click **STABILIZED**. The `FLIGHT MODE` label should update to `STABILIZED`. If it does not, check that the Remote Control widget is actively publishing.
+    1.  Click **ARM**. The motors will start spinning at idle RPM.
+    1.  Slowly raise the **throttle** (push the left gimbal up) until the drone lifts off. PX4 keeps it level while you hold the throttle.
+    1.  Steer with the **right gimbal** (roll and pitch) and rotate with **yaw** (left gimbal, left/right).
+    1.  There is **no altitude hold**. You manage height with the throttle throughout the flight.
+    1.  To land, ease the throttle down until the drone touches down, then click **DISARM**.
+    :::
+
+    :::{tab-item} Fly with PX4's attitude stabilization (auto altitude hold)
 
     1.  In the **Remote Control** widget, center the sticks and set `Throttle` slightly above the mid-point.
     1.  In the arming widget, click **ALTITUDE**.
         *   The `FLIGHT MODE` label should update to `ALTITUDE`. If it stays on `LOITER`, PX4 rejected the request — check that the Remote Control widget is actively publishing.
     1.  Gradually increase the throttle. The drone will ascend and PX4 will hold altitude once the sticks are centered.
-    1.  Use roll/pitch on the virtual joystick to move horizontally. The yaw on the secondary joystick rotates the drone.
+    1.  Use roll/pitch on the **right gimbal** to move horizontally. Yaw (**left gimbal**, left/right) rotates the drone.
     1.  To land, decrease the throttle gradually. When the drone is close to the ground, click **DISARM**.
     :::
 

--- a/src/_static/dd24-b-fc-parameters/duckiedrone-px4-v2.params
+++ b/src/_static/dd24-b-fc-parameters/duckiedrone-px4-v2.params
@@ -114,10 +114,10 @@
 # What to do when the battery runs low. 3 = land.
 1	1	COM_LOW_BAT_ACT	3	6
 # What the drone does if it loses the data link to the companion computer (the
-# Pi running MAVROS). 2 = try to fly back home ("return"). This drone has no
-# GPS, so a real return home cannot actually happen here.
+# Pi running MAVROS). 0 = disabled (no action). We disable this check since the
+# drone has no GPS, so a real return home cannot happen anyway.
 # Ref: https://docs.px4.io/v1.15/en/advanced_config/parameter_reference.html#NAV_DLL_ACT
-1	1	NAV_DLL_ACT	2	6
+1	1	NAV_DLL_ACT	0	6
 # By default PX4 also treats a lost radio-control link as an emergency.
 # This lets some modes carry on without one. 4 = allow it in OFFBOARD, so the
 # companion computer can drive the drone with no RC transmitter plugged in.

--- a/src/_static/dd24-b-fc-parameters/duckiedrone-px4-v2.params
+++ b/src/_static/dd24-b-fc-parameters/duckiedrone-px4-v2.params
@@ -1,86 +1,128 @@
-# Onboard parameters for Duckiedrone DD24-B (PX4 mamba-f405-mk2, mamba-imu build)
+# Flight controller settings for the DD24-B Duckiedrone (PX4).
 #
-# v2 - rebuilt empirically from a factory-reset FC, applying and reading back
-# every parameter on the ACTUAL shipping firmware. Only params that exist and
-# persist on this build are included. See DTSW-7245 / -7484 / -7822 / -7823.
+# This file holds all the settings the drone's flight controller needs in order
+# to fly: what shape the frame is, where the motors are and which way they spin,
+# which sensors are fitted, and how the drone should behave. Loading it all at
+# once saves you from typing in dozens of settings by hand.
 #
-# KEY DIFFERENCE FROM v1: this build is flash-stripped and DOES NOT run any
-# ROMFS airframe script. SYS_AUTOSTART is therefore inert - selecting an
-# airframe (in QGC or via param) populates NOTHING. The full quad-X frame must
-# be defined EXPLICITLY via the CA_* block below (this is what v1 was missing:
-# it set the KM signs but never the rotor positions, leaving geometry at zero).
+# How to use it: open QGroundControl, connect the flight controller over USB,
+# then go to Vehicle Setup > Parameters > Tools > Load from file, choose this
+# file, and reboot the flight controller when it asks.
 #
-# REMOVED vs v1 (phantom on this build - 'param set' returns "not found"):
-#   IMU_GYRO_FFT_EN, MC_AT_EN, COM_MODE_ARM_CHK,
-#   SDLOG_DIRS_MAX, SDLOG_MODE, SDLOG_PROFILE
-#   -> the gyro-FFT, autotune and logger modules are not compiled in.
-#      NOTE: no logger module => NO flight logging (.ulg) on this firmware.
-# REMOVED vs v1 (invalid / no-op):
-#   EKF2_GPS_CHECK (2047 > max 511, clamps; moot with GPS off)
-#   EKF2_REQ_GPS_H (moot with GPS off)
+# One thing you still do yourself afterwards: calibrate the sensors
+# (accelerometer, gyroscope and level horizon) in QGroundControl. Those readings
+# are different for every board, so they are not saved in here.
 #
-# NOT INCLUDED (per-board, calibrate on target via QGC after loading):
-#   CAL_* (accelerometer, gyro, level horizon). Skip compass/mag (none fitted).
-#
-# Frame geometry is explicit and self-contained (normalized +/-1 positions);
-# KM signs define props-in: rotors 0,1 = CCW (+), rotors 2,3 = CW (-).
-# Match each ESC's physical spin to these via Bluejay dshot reverse/save.
+# Each setting below has a short note above it explaining what it does. You do
+# not need to understand every line to use the file; the notes are just there
+# if you are curious. A few of them link to the PX4 documentation if you want to
+# read more.
 #
 # Vehicle-Id Component-Id Name Value Type
-# --- System / airframe label (inert on this build, kept for QGC display) ---
+#
+# --- Airframe name ---
+# SYS_AUTOSTART picks a ready-made "recipe" for the airframe (4001 = a generic
+# quad in X layout). On a normal PX4 that recipe would set up the whole frame
+# for you. This stripped-down build does not run the recipe, so the number does
+# nothing here except show a friendly name in QGroundControl. The real frame is
+# built by hand in the CA_ block just below.
 1	1	SYS_AUTOSTART	4001	6
-# --- Frame type + explicit quad-X control allocation geometry ---
+# --- Frame shape and motor layout ---
+# Tells everyone "I am a quadcopter" (2 = quad). QGC and MAVROS read this to
+# draw the right icon and pick sensible defaults.
 1	1	MAV_TYPE	2	6
+# The kind of vehicle for the motor-mixing math. 0 = multirotor.
 1	1	CA_AIRFRAME	0	6
+# How many motors we have. Four.
 1	1	CA_ROTOR_COUNT	4	6
+# The next block tells PX4 exactly where each motor sits and which way it spins,
+# so it can work out how to mix them for roll, pitch and yaw. Positions are
+# normalized: PX is front (+) / back (-), PY is right (+) / left (-). KM is the
+# spin direction: a plus sign means the propeller turns counter-clockwise, a
+# minus sign means clockwise. This pattern is "props-in".
+# More on control allocation: https://docs.px4.io/v1.15/en/config/actuators.html
+# Motor 1: front-right corner, spins counter-clockwise.
 1	1	CA_ROTOR0_PX	1.0	9
 1	1	CA_ROTOR0_PY	1.0	9
 1	1	CA_ROTOR0_KM	0.05	9
+# Motor 2: rear-left corner, spins counter-clockwise.
 1	1	CA_ROTOR1_PX	-1.0	9
 1	1	CA_ROTOR1_PY	-1.0	9
 1	1	CA_ROTOR1_KM	0.05	9
+# Motor 3: front-left corner, spins clockwise.
 1	1	CA_ROTOR2_PX	1.0	9
 1	1	CA_ROTOR2_PY	-1.0	9
 1	1	CA_ROTOR2_KM	-0.05	9
+# Motor 4: rear-right corner, spins clockwise.
 1	1	CA_ROTOR3_PX	-1.0	9
 1	1	CA_ROTOR3_PY	1.0	9
 1	1	CA_ROTOR3_KM	-0.05	9
-# --- Outputs: MAIN1-4 -> Motor1-4, DShot600 (TIMx = -3) ---
+# --- Motor outputs ---
+# Which motor each output pin drives. Output 1 goes to Motor 1, output 2 to
+# Motor 2, and so on (101..104 are PX4's codes for "Motor 1".."Motor 4").
 1	1	PWM_MAIN_FUNC1	101	6
 1	1	PWM_MAIN_FUNC2	102	6
 1	1	PWM_MAIN_FUNC3	103	6
 1	1	PWM_MAIN_FUNC4	104	6
+# The language the flight controller speaks to the ESCs. -3 means DShot600, a
+# fast digital protocol (not the old analog PWM). Both motor timer groups use it.
 1	1	PWM_MAIN_TIM0	-3	6
 1	1	PWM_MAIN_TIM1	-3	6
-1	1	PWM_MAIN_MIN1	1100	6
-1	1	PWM_MAIN_MIN2	1100	6
-1	1	PWM_MAIN_MIN3	1100	6
-1	1	PWM_MAIN_MIN4	1100	6
-1	1	PWM_MAIN_MAX1	1900	6
-1	1	PWM_MAIN_MAX2	1900	6
-1	1	PWM_MAIN_MAX3	1900	6
-1	1	PWM_MAIN_MAX4	1900	6
-# --- Sensor presence: no baro / mag / gps on the v2 board ---
+# --- Which sensors are fitted ---
+# These tell PX4 which sensors are really on the board. This drone has no
+# barometer, no compass (magnetometer) and no GPS, so all three are 0.
 1	1	SYS_HAS_BARO	0	6
 1	1	SYS_HAS_MAG	0	6
 1	1	SYS_HAS_GPS	0	6
-# --- EKF2: rangefinder-only height, no baro/gps/mag/vision/flow fusion ---
+# --- Position and height estimation ---
+# EKF2 is the math that estimates where the drone is and how high it is by
+# blending the sensors together. Since the only things we have are the IMU and
+# a downward range sensor (ToF), we switch off every source we do not have and
+# tell it to trust the range sensor for height.
+# Full list: https://docs.px4.io/v1.15/en/advanced_config/parameter_reference.html
+# Do not use a barometer for height.
 1	1	EKF2_BARO_CTRL	0	6
+# Do not use GPS.
 1	1	EKF2_GPS_CTRL	0	6
+# Do not use external vision or a motion-capture system.
 1	1	EKF2_EV_CTRL	0	6
+# Do not use an optical-flow camera.
 1	1	EKF2_OF_CTRL	0	6
+# Do not use a compass at all (5 = none), so the estimator never tries to.
 1	1	EKF2_MAG_TYPE	5	6
+# Use our bottom facing ToF Sensor for Height estimate
 1	1	EKF2_HGT_REF	2	6
+# Turn on using the downward range sensor inside the estimator (1 = enabled).
 1	1	EKF2_RNG_CTRL	1	6
+# The closest distance (in meters) a range reading is trusted from.
 1	1	EKF2_MIN_RNG	0.01	9
-# --- IMU / filtering ---
+# --- Motion sensor (IMU) ---
+# The IMU has accelerometers and gyroscopes. 
+# The next three lines tune how its signal is sampled and smoothed.
+# Smooth the gyro's rate-of-change signal by trimming noise above 20 Hz.
 1	1	IMU_DGYRO_CUTOFF	20.0	9
+# How many gyro samples per second are handed to the controller (800 per second).
 1	1	IMU_GYRO_RATEMAX	800	6
+# How often (times per second) IMU readings are bundled up for the estimator.
 1	1	IMU_INTEG_RATE	250	6
-# --- Safety / battery / comms ---
+# --- Safety, battery and communication ---
+# A "circuit breaker" that switches off the power-supply sanity check. 894281 is
+# the specific unlock number PX4 expects.
 1	1	CBRK_SUPPLY_CHK	894281	6
+# How many cells the flight battery has. Ours is a 4-cell (4S) pack.
 1	1	BAT1_N_CELLS	4	6
+# What to do when the battery runs low. 3 = land.
 1	1	COM_LOW_BAT_ACT	3	6
+# What the drone does if it loses the data link to the companion computer (the
+# Pi running MAVROS). 2 = try to fly back home ("return"). This drone has no
+# GPS, so a real return home cannot actually happen here.
+# Ref: https://docs.px4.io/v1.15/en/advanced_config/parameter_reference.html#NAV_DLL_ACT
 1	1	NAV_DLL_ACT	2	6
+# By default PX4 also treats a lost radio-control link as an emergency.
+# This lets some modes carry on without one. 4 = allow it in OFFBOARD, so the
+# companion computer can drive the drone with no RC transmitter plugged in.
+# Ref: https://docs.px4.io/v1.15/en/advanced_config/parameter_reference.html#COM_RCL_EXCEPT
 1	1	COM_RCL_EXCEPT	4	6
+# Which version of the MAVLink messaging language to speak. 2 = MAVLink 2, the
+# modern one that MAVROS and QGroundControl expect.
 1	1	MAV_PROTO_VER	2	6


### PR DESCRIPTION
Every arm attempt through Mavros (dashboard or CLI) was rejected (COMMAND_ACK result=1), with no visible reason, regardless of mode/RC health.

Root-caused in PX4 source (Commander.cpp, HealthAndArmingChecks/checks/rcAndDataLinkCheck.cpp): arming is blocked whenever gcs_connection_lost == true and NAV_DLL_ACT > 0. gcs_connection_lost is cleared only by a heartbeat declaring MAV_TYPE_GCS; 
mavros hardcodes its own heartbeat type as MAV_TYPE_ONBOARD_CONTROLLER and can never satisfy this,

NAV_DLL_ACT defaults to 0 (disabled) in stock PX4. 
Still, the project's params file explicitly sets it to 2 (Return-on-datalink-loss) as part of earlier OFFBOARD/companion-computer tuning, without realising the side effect. 

Fix: set NAV_DLL_ACT=0 on the FC (Return was never going to work on this GPS-less airframe anyway). 
Verified via a controlled A/B test (identical arm command, MAV_TYPE_GCS vs MAV_TYPE_ONBOARD_CONTROLLER identity) 

So updating the params flashed on the drone takes care of this.

Also adding an explanation for each parameter that's flashed on the FC